### PR TITLE
improvement of navigation bar 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,23 +13,13 @@ function App() {
     const [jwt, setJwt] = useState(localStorage.getItem("jwt"));
     const [role, setRole] = useState(localStorage.getItem("role"));
 
-    //login
+    //login function
     function handleLogin(jwt, role) {
         setJwt(jwt);
         setRole(role);
     }
 
-    // //logout
-    // function handleLogout() {
-    //     //clear credentials from localstorage
-    //     localStorage.removeItem("jwt");
-    //     localStorage.removeItem("role");
-    //     localStorage.removeItem("username");
-    //
-    //     //clear State
-    //     setJwt(null);
-    //     setRole(null);
-    // }
+
 
 
     return (
@@ -38,8 +28,8 @@ function App() {
             <Route path="/" element={<LoginPage onLogin={handleLogin}/>} />
             <Route path="/usermanagement" element={localStorage.getItem("jwt") && localStorage.getItem("role") === "ADMIN" ? <UserManagementPage/> :<Navigate to="/"/>}/>
             <Route path="/overview"  element={jwt? <OverviewPage/> :<Navigate to="/" />} />
-            <Route path="/my-garden" element={jwt? <MyGardenPage/> : <Navigate to="/overview"/>} />
-            <Route path = "/catalog" element={jwt? <PlantcatalogPage/> :<Navigate to="/overview"/>}/>
+            <Route path="/my-garden" element={jwt? <MyGardenPage/> : <Navigate to="/"/>} />
+            <Route path = "/catalog" element={jwt? <PlantcatalogPage/> :<Navigate to="/"/>}/>
             <Route path = "/plants/new" element={jwt ? <PlantFormPage mode = "create"/> : <Navigate to="/catalog" /> } />
             <Route path = "/plants/:id/edit" element={jwt ? <PlantFormPage mode = "edit"/> : <Navigate to="/catalog" /> } />
         </Routes>

--- a/src/components/layout/navigationbar/NavigationBar.jsx
+++ b/src/components/layout/navigationbar/NavigationBar.jsx
@@ -1,19 +1,53 @@
 import React from "react";
-import { Link, NavLink } from 'react-router-dom';
+import {  NavLink, useNavigate } from 'react-router-dom';
 import styles from './NavigationBar.module.css';
+import {House, SignOut} from "phosphor-react";
+import Button from "../../ui/button/Button.jsx";
 
 function NavigationBar(){
+
+    const navigate = useNavigate();
+    //constants needed for logout function "handleLogout"
+    const role = localStorage.getItem("role"); // "DESIGNER" or "ADMIN"
+    const username = localStorage.getItem("username");
+
+    //log out by deleting credentials and jwt from local storage. the Routing defined below will automatically redirect to login page when there is no jwt present
+    function handleLogout() {
+        localStorage.removeItem("jwt");
+        localStorage.removeItem("role");
+        localStorage.removeItem("username");
+
+        navigate("/");
+    }
+
+
+
     return(
         <>
             <nav>
                 <ul>
-                    <li>  <NavLink
+                    <li>
+                        {/*Overview page "Start" -- all roles */}
+                        <NavLink
                         className={({ isActive}) => isActive ? 'active-menu-link':'default-menu-link'}
                         to = "/overview">
-                        {/*<House size={32} color="#3b4d3c" weight="fill" /> */}
+                        <House size={32} color="#3b4d3c" weight="fill" />
                         Start
                         </NavLink>
                     </li>
+
+                    {/*Plant catalog page " Planten catalogus -- all roles"*/}
+
+                    <li>
+                        <NavLink
+                            className={({ isActive}) => isActive ? 'active-menu-link':'default-menu-link'}
+                            to = "/catalog">
+                            Planten catalogus
+                        </NavLink>
+                    </li>
+
+                    {/* MyGarden page "Mijn tuin" -- DESIGNER only*/}
+                    {role?.toUpperCase() === "DESIGNER" && (
                     <li>
                         <NavLink
                         className={({ isActive}) => isActive ? 'active-menu-link':'default-menu-link'}
@@ -21,27 +55,36 @@ function NavigationBar(){
                         Mijn tuin
                         </NavLink>
                     </li>
+                    )}
 
-                    <li>
+                    {/* Usermanagement page "Accounts beheren" -- ADMIN only*/}
+                    { role?.toUpperCase() === "ADMIN" && (
+                        <li>
                         <NavLink
-                            className={({ isActive}) => isActive ? 'active-menu-link':'default-menu-link'}
-                            to = "/catalog">
-                                Plantjes catalogus
-                        </NavLink>
-                    </li>
-
-                    <li>     <NavLink
                         className={({ isActive}) => isActive ? 'active-menu-link':'default-menu-link'}
                         to = "/usermanagement">
                         Accounts beheren
                     </NavLink>
                     </li>
+                    )}
 
-                    <li><button type="button">account</button></li>
-                    {/*<User size={32} color="#3b4d3c" weight="fill" />*/}
-                    {/*<SignOut size={32} color="#3b4d3c" weight="fill" />*/}
-                    <li><p>huidige inlognaam</p></li>
-                    <li><button type="button">uitloggen</button></li>
+                    <li className={styles.userInfo}>
+                        <span>{username}</span>
+                    </li>
+
+
+                    <li>
+
+                    <Button
+                        type="button"
+                        onClick={handleLogout}
+                    >
+                        <SignOut size={32} color="#3b4d3c" weight="fill" /> Uitloggen
+                    </Button>
+                    </li>
+
+
+
                 </ul>
             </nav>
         </>

--- a/src/components/layout/navigationbar/NavigationBar.module.css
+++ b/src/components/layout/navigationbar/NavigationBar.module.css
@@ -7,9 +7,13 @@ nav > ul{
 
 nav{
     padding: 10px;
-
     background-color: var(--tea-green);
 }
+
+.userInfo{}
+
+
+
 
 .active-menu-link {
     background-color: var(--highlight);

--- a/src/components/pages/overviewpage/OverviewPage.jsx
+++ b/src/components/pages/overviewpage/OverviewPage.jsx
@@ -7,8 +7,9 @@ import axios from "axios";
 
 
 
+
 function OverviewPage(){
-    //this page is always loaded after successful login, so this is logical location for an API call to obtain user info and store it in local Storage
+    //this page is always loaded after successful login, so this is logical location for an API call to obtain user info and store it in local Storage for later use
     const [jwt, setJwt] = useState(localStorage.getItem("jwt"));
     const [role, setRole] = useState(localStorage.getItem("role"));
     const [username, setUsername] = useState(localStorage.getItem("username"));

--- a/src/components/pages/plantFormPage/PlantFormPage.jsx
+++ b/src/components/pages/plantFormPage/PlantFormPage.jsx
@@ -6,7 +6,7 @@ function PlantFormPage(){
     return(
         <>
             <header>
-                <NavigationBar/>
+                <NavigationBar />
             </header>
 
             <main>

--- a/src/components/pages/plantcatalogPage/PlantcatalogPage.jsx
+++ b/src/components/pages/plantcatalogPage/PlantcatalogPage.jsx
@@ -76,6 +76,8 @@ function PlantcatalogPage(){
 
     //get SelectedPlants from the Design of the user: first define fetchDesign as a reusable function, because it is needed for both loading the page for the first time and updating SelectedPlants
     async function fetchDesign() {
+
+
         try {
             const jwt = localStorage.getItem("jwt");
 
@@ -93,8 +95,9 @@ function PlantcatalogPage(){
             setError("Kon tuinontwerp niet ophalen");
         }
     }
-    //useEffect to load design for the first time
+    //useEffect to load design (DESIGNER role only) for the first time
     useEffect(() => {
+        if(user?.role === "DESIGNER" )
         fetchDesign();
     }, []);
 
@@ -201,8 +204,6 @@ function PlantcatalogPage(){
                     {loading && <p> Planten laden...</p>}
 
 
-                    <p>Ingelogd als: {user?.username} ({user?.role}) </p>
-
                     {user?.role === "ADMIN" && (
                         <Link to="/plants/new">
                             <Button type="button">
@@ -254,11 +255,14 @@ function PlantcatalogPage(){
 
                 </section>
 
+                {/*show aside only when role === "DESIGNER"*/}
+                { user?.role === "DESIGNER" && (
                 <SelectedPlantsAside
                     selectedPlants={selectedPlants}
                     onAmountChange={handleUpdateSelectedPlantAmount}
                     onDelete={handleDeleteSelectedPlant}
                 />
+                    )}
             </main>
 
         </>


### PR DESCRIPTION
applied conditional rendering to navigationbar for the different roles: only navigation buttons are shown for which the user has the applicable role. 

Similar to this: improved plantcatalog page to only get design data from the backend and show the selectedPlants aside  element when the user role is Designer. Otherwise admin-users are shown a 403 forbidden error and an empty aside because the backend only allows designers to design related endpoints. 